### PR TITLE
fix(branch-protection): disable branch protection settings for private repositories

### DIFF
--- a/modules/github-repository/main.tf
+++ b/modules/github-repository/main.tf
@@ -21,7 +21,7 @@ resource "github_repository" "self" {
 }
 
 resource "github_branch_protection" "self" {
-  count = try(var.has_branch_protection ? 1 : 0, 1)
+  count = var.visibility == "public" && var.has_branch_protection ? 1 : 0
 
   allows_deletions                = false
   allows_force_pushes             = false


### PR DESCRIPTION
The organization is a free tier so we cannot use branch protection features on private repositories